### PR TITLE
Fixed navigation media query issues

### DIFF
--- a/Altr.Frontend/angular.json
+++ b/Altr.Frontend/angular.json
@@ -105,5 +105,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": "8ee3052a-3b87-4bce-a12a-d08ea0a0d96c"
   }
 }

--- a/Altr.Frontend/src/app/navigation/navigation.component.ts
+++ b/Altr.Frontend/src/app/navigation/navigation.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { MatSidenav } from '@angular/material/sidenav';
 
@@ -11,7 +11,7 @@ export class NavigationComponent implements AfterViewInit {
   @ViewChild(MatSidenav)
   sidenav!  : MatSidenav;
 
-  constructor(private observer: BreakpointObserver) { }
+  constructor(private observer: BreakpointObserver, private cdr: ChangeDetectorRef) { }
 
   ngAfterViewInit(): void {
       this.observer.observe(['(max-width: 800px']).subscribe((res) => {
@@ -22,7 +22,10 @@ export class NavigationComponent implements AfterViewInit {
           this.sidenav.mode = 'side';
           this.sidenav.open();
         }
-      });
+      })
+
+      // manually trigger change detection for the current component. 
+      this.cdr.detectChanges();
   }
 
 }

--- a/Altr.Frontend/src/app/navigation/navigation.component.ts
+++ b/Altr.Frontend/src/app/navigation/navigation.component.ts
@@ -14,7 +14,7 @@ export class NavigationComponent implements AfterViewInit {
   constructor(private observer: BreakpointObserver, private cdr: ChangeDetectorRef) { }
 
   ngAfterViewInit(): void {
-      this.observer.observe(['(max-width: 800px']).subscribe((res) => {
+      this.observer.observe(['(max-width: 800px)']).subscribe((res) => {
         if(res.matches) {
           this.sidenav.mode = 'over';
           this.sidenav.close();


### PR DESCRIPTION
The problem is actually happening inside of navigation.component.ts under the ngAfterViewInit life cycle. This occur when the functionality wants to embedded CSS rule inside the project stylesheet & the other issue when trying to run the app on Firefox browser, this two issues happened within the same cycle of the same file.

Below shows a reference which are related to the errors:

1. [[DOMException: Failed to execute styleSheet.insertRule](https://stackoverflow.com/questions/56756620/domexception-failed-to-execute-stylesheet-insertrule)](https://stackoverflow.com/questions/56756620/domexception-failed-to-execute-stylesheet-insertrule)
2. [[xpression ___ has changed after it was checked](https://stackoverflow.com/questions/34364880/expression-has-changed-after-it-was-checked)](https://stackoverflow.com/questions/34364880/expression-has-changed-after-it-was-checked/35243106#35243106)