### PR TITLE
Add confirm dialog when the forms is touched

### DIFF
--- a/Altr.Frontend/src/app/app.module.ts
+++ b/Altr.Frontend/src/app/app.module.ts
@@ -96,6 +96,6 @@ const Pages_Components = [
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   providers: [DialogModalService, { provide: HTTP_INTERCEPTORS, useClass: BackEndErrorInterceptor, multi: true}],
   bootstrap: [AppComponent],
-  entryComponents: [ModalViewComponent]
+  entryComponents: [ModalViewComponent, ModalConfirmComponent]
 })
 export class AppModule { }

--- a/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-confirm/modal-confirm.component.html
+++ b/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-confirm/modal-confirm.component.html
@@ -1,12 +1,12 @@
 <div [ngClass]="{'shake': shakeIt, 'dialog-class': true}">
     <div class="header">
-        <h2 mat-dialog-title>title</h2>
+        <h2 mat-dialog-title>{{ data.titleSrc }}</h2>
     </div>
     <div mat-dialog-content>
-        Are you sure you want to do this?
+        {{ data.contentSrc }}
     </div>
     <div mat-dialog-actions [align]="'end'">
-        <button mat-raised-button color="warn" [mat-dialog-close]="true">No</button>
-        <button mat-raised-button color="primary" [mat-dialog-close]="false">Yes</button>
+        <button mat-raised-button color="warn" (click)="cancel()">{{ data.cancelText }}</button>
+        <button mat-raised-button color="primary" (click)="confirm()">{{ data.confirmText }}</button>
     </div>
 </div>

--- a/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-confirm/modal-confirm.component.ts
+++ b/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-confirm/modal-confirm.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-modal-confirm',
@@ -8,9 +10,25 @@ import { Component, OnInit } from '@angular/core';
 export class ModalConfirmComponent implements OnInit {
   shakeIt = false;
   
-  constructor() { }
+  constructor(@Inject (MAT_DIALOG_DATA) public data: {
+    titleSrc: string;
+    contentSrc: FormGroup | string;
+    cancelText: string;
+    confirmText: string;
+  }, private mdDialogRef: MatDialogRef<ModalConfirmComponent>) { }
 
   ngOnInit(): void {
   }
 
+  public cancel(): void {
+    this.close(false);
+  }
+
+  public close(value: boolean): void {
+    this.mdDialogRef.close(value);
+  }
+
+  public confirm(): void {
+    this.close(true);
+  }
 }

--- a/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-create/modal-create.component.ts
+++ b/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-create/modal-create.component.ts
@@ -1,6 +1,9 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { filter, map } from 'rxjs';
+import { DialogModalService } from 'src/app/foundation/services/dialog-modal.service';
+import { AltrDialog } from 'src/app/foundation/types';
 
 @Component({
   selector: 'app-modal-create',
@@ -17,7 +20,8 @@ export class ModalCreateComponent implements OnInit {
     contentSrc: FormGroup;
     cancelText: string;
     confirmText: string;
-  }, private mdDialogRef: MatDialogRef<ModalCreateComponent>, private fb: FormBuilder) {
+  }, private mdDialogRef: MatDialogRef<ModalCreateComponent>, 
+     private dialogService: DialogModalService) {
     // Copy formgroup to another formgroup
     this.form = data.contentSrc
    }
@@ -30,8 +34,30 @@ export class ModalCreateComponent implements OnInit {
   }
 
   public cancel(): void {
-    this.close(false);
+    if (!this.form.pristine && this.form.touched ) {
+      this.dialogService.openConfirm(this.assignConfirmContent())
+      this.executeConfirmDialog();
+    } else {
+      this.close(false);
+    }
   }
+
+  assignConfirmContent(): AltrDialog {
+    return {
+      titleSrc: 'Confirmation',
+      contentSrc: 'Are you sure you want to do this?',
+      cancelText: 'No',
+      confirmText: 'Yes'
+    }
+  }
+
+  executeConfirmDialog(): void {
+    this.dialogService.confirmed().pipe(
+      filter((resp) => resp),
+      map(() => this.close(true))
+    ).subscribe()
+  }
+  
 
   // Will send result to the dialog opener, place where the dialog is open/initialized
   // in this case the opener is in category component. 
@@ -41,7 +67,6 @@ export class ModalCreateComponent implements OnInit {
 
   public confirm(): void {
     // Try adding validation here before proceed to backend
-
     if (this.form.valid) {
       this.close(this.form)
     } else {

--- a/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-edit/modal-edit.component.ts
+++ b/Altr.Frontend/src/app/foundation/reusable-component/a-ltr-modal/modal-edit/modal-edit.component.ts
@@ -1,6 +1,9 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { filter, map } from 'rxjs';
+import { DialogModalService } from 'src/app/foundation/services/dialog-modal.service';
+import { AltrDialog } from 'src/app/foundation/types';
 
 @Component({
   selector: 'app-modal-edit',
@@ -17,7 +20,8 @@ export class ModalEditComponent implements OnInit {
     contentSrc: FormGroup;
     cancelText: string;
     confirmText: string;
-  }, private mdDialogRef: MatDialogRef<ModalEditComponent>) {
+  }, private mdDialogRef: MatDialogRef<ModalEditComponent>,
+     private dialogService: DialogModalService) {
     // Copy formgroup to another formgroup
     this.form = data.contentSrc
    }
@@ -30,8 +34,30 @@ export class ModalEditComponent implements OnInit {
   }
 
   public cancel(): void {
-    this.close(false);
+    if (!this.form.pristine && this.form.touched ) {
+      this.dialogService.openConfirm(this.assignConfirmContent())
+      this.executeConfirmDialog();
+    } else {
+      this.close(false);
+    }
   }
+
+  assignConfirmContent(): AltrDialog {
+    return {
+      titleSrc: 'Confirmation',
+      contentSrc: 'Are you sure you want to do this?',
+      cancelText: 'No',
+      confirmText: 'Yes'
+    }
+  }
+
+  executeConfirmDialog(): void {
+    this.dialogService.confirmed().pipe(
+      filter((resp) => resp),
+      map(() => this.close(true))
+    ).subscribe()
+  }
+  
 
   // Will send result to the dialog opener, place where the dialog is open/initialized
   // in this case the opener is in category component. 

--- a/Altr.Frontend/src/app/foundation/services/dialog-modal.service.ts
+++ b/Altr.Frontend/src/app/foundation/services/dialog-modal.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import {map, take} from 'rxjs/operators';
 import { ModalCreateComponent } from '../reusable-component/a-ltr-modal/modal-create/modal-create.component';
 import { ModalEditComponent } from '../reusable-component/a-ltr-modal/modal-edit/modal-edit.component';
+import { ModalConfirmComponent } from '../reusable-component/a-ltr-modal/modal-confirm/modal-confirm.component';
 
 @Injectable({
   providedIn: 'root'
@@ -16,11 +17,13 @@ export class DialogModalService {
   dialogRefView: MatDialogRef<ModalViewComponent>;
   dialogRefCreate: MatDialogRef<ModalCreateComponent>;
   dialogRefEdit: MatDialogRef<ModalEditComponent>;
+  dialogRefConfirm: MatDialogRef<ModalConfirmComponent>;
 
   //  Fetch dialog opening action for view category modal
   public openView(options: any) {
     this.dialogRefView = this.dialog.open(ModalViewComponent, {
       disableClose: true,
+      autoFocus: false,
       data: {
         titleSrc: options.titleSrc,
         contentSrc: options.contentSrc,
@@ -56,9 +59,22 @@ export class DialogModalService {
     })
   }
 
+  public openConfirm(options: any) {
+    this.dialogRefConfirm = this.dialog.open(ModalConfirmComponent, {
+      disableClose: true,
+      data: {
+        titleSrc: options.titleSrc,
+        contentSrc: options.contentSrc,
+        cancelText: options.cancelText,
+        confirmText: options.confirmText
+      }    
+    })
+  }
+
+
   // Fetch current action of a close dialog, in this case it will be categorised by different mode of modal
   public confirmed(): Observable<any> {
-    const dialogRefCol = [this.dialogRefView, this.dialogRefEdit, this.dialogRefCreate];
+    const dialogRefCol = [this.dialogRefView, this.dialogRefEdit, this.dialogRefCreate, this.dialogRefConfirm];
     let endResult$: Observable<any>;
     //  When the dialog is finish closing it will then return the result of observable back to the one who's call this method
     //  in this case, the one who call this message to fetch the result is the one who's calling the openCreate()

--- a/Altr.Frontend/src/app/foundation/types.ts
+++ b/Altr.Frontend/src/app/foundation/types.ts
@@ -20,7 +20,7 @@ export interface AltrTableColumn {
 
 export interface AltrDialog {
     titleSrc: string;
-    contentSrc: FormGroup;
+    contentSrc: FormGroup | string;
     cancelText: string;
     confirmText?: string;
 }


### PR DESCRIPTION
- Add confirm dialog for edit and create dialog form (category section)
- Refactor confirm dialog functionality
- Both Edit and Create uses the same confirm dialog functionality
- Update interface for holding generic modal content